### PR TITLE
Update API to be compatible with changes to Txn.Set()

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -51,7 +51,7 @@ func (d *datastore) Put(key ds.Key, value interface{}) error {
 	txn := d.DB.NewTransaction(true)
 	defer txn.Discard()
 
-	err := txn.Set(key.Bytes(), val, 0)
+	err := txn.Set(key.Bytes(), val)
 	if err != nil {
 		return err
 	}
@@ -207,7 +207,7 @@ func (b *badgerBatch) Put(key ds.Key, value interface{}) error {
 		return ds.ErrInvalidType
 	}
 
-	err := b.txn.Set(key.Bytes(), val, 0)
+	err := b.txn.Set(key.Bytes(), val)
 	if err != nil {
 		b.txn.Discard()
 	}


### PR DESCRIPTION
We made a small change to the public API in this change: https://github.com/dgraph-io/badger/pull/305

The `Txn.Set()` method now takes only 2 arguments (a key and a value), with other helper methods to setuser metadata and TTL.

This was an easy feature to implement, but it also meant a change to the on-disk format. So we wanted to get this out before v1.0 because we were gonna upgrade the manifest version anyway. Sorry for the inconvenience.