### PR TITLE
Remove call to deprecated/removed PurgeOlderVersions

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -256,12 +256,7 @@ func (b *badgerBatch) Commit() error {
 }
 
 func (d *datastore) CollectGarbage() error {
-	err := d.DB.PurgeOlderVersions()
-	if err != nil {
-		return err
-	}
-
-	err = d.DB.RunValueLogGC(d.gcDiscardRatio)
+	err := d.DB.RunValueLogGC(d.gcDiscardRatio)
 	if err == badger.ErrNoRewrite {
 		err = nil
 	}

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     },
     {
       "author": "dgraph-io",
-      "hash": "QmeAEa8FDWAmZJTL6YcM1oEndZ4MyhCr5rTsjYZQui1x1L",
+      "hash": "QmUkYC4JT54xVUW83oJMrPw9SLnrRQ1UUvPySdt3uEz4uy",
       "name": "badger",
-      "version": "2.6.1"
+      "version": "2.7.0"
     }
   ],
   "gxVersion": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "license": "",
   "name": "go-ds-badger",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.4.7"
+  "version": "1.4.8"
 }
 


### PR DESCRIPTION
This function was removed in v1.5.0, per the Badger README. As of today, master won't compile against the latest badger release.