### PR TITLE
Truncate over-allocated vlog on Windows

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	osh "github.com/Kubuxu/go-os-helper"
 	badger "github.com/dgraph-io/badger"
 
 	ds "github.com/ipfs/go-datastore"
@@ -43,6 +44,10 @@ func NewDatastore(path string, options *Options) (*datastore, error) {
 	} else {
 		opt = options.Options
 		gcDiscardRatio = options.gcDiscardRatio
+	}
+
+	if osh.IsWindows() && opt.SyncWrites {
+		opt.Truncate = true
 	}
 
 	opt.Dir = path

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
       "hash": "QmUkYC4JT54xVUW83oJMrPw9SLnrRQ1UUvPySdt3uEz4uy",
       "name": "badger",
       "version": "2.7.0"
+    },
+    {
+      "author": "Kubuxu",
+      "hash": "QmXuBJ7DR6k3rmUEKtvVMhwjmXDuJgXXPUt4LQXKBMsU93",
+      "name": "go-os-helper",
+      "version": "0.0.0"
     }
   ],
   "gxVersion": "0.8.0",


### PR DESCRIPTION
badger has to allocate it's vlogs up front on Windows and truncate later. If the process crashes at the wrong time, there will be padding beyond the actual written data , badger can detect that and safely truncate it. On other platforms, data loss is implied with truncation, since files are allocated as needed, but that is not the case on Windows since the whole log is allocated up front, data beyond the bounds should always be garbage and can be safely trimmed.

![vlog](https://user-images.githubusercontent.com/13862850/42038938-2c1dcba8-7aba-11e8-8a55-ee4d5d0ec838.png)
