### PR TITLE
always truncate when SyncWrites is enabled

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	osh "github.com/Kubuxu/go-os-helper"
 	badger "github.com/dgraph-io/badger"
 
 	ds "github.com/ipfs/go-datastore"
@@ -53,7 +52,7 @@ func NewDatastore(path string, options *Options) (*Datastore, error) {
 		gcDiscardRatio = options.gcDiscardRatio
 	}
 
-	if osh.IsWindows() && opt.SyncWrites {
+	if opt.SyncWrites {
 		opt.Truncate = true
 	}
 

--- a/package.json
+++ b/package.json
@@ -24,12 +24,6 @@
       "hash": "Qmb3GBFCHMuzmi9EpH3pxpYBiviyc3tEPyDQHxZJQJSxj9",
       "name": "badger",
       "version": "2.7.3"
-    },
-    {
-      "author": "Kubuxu",
-      "hash": "QmXuBJ7DR6k3rmUEKtvVMhwjmXDuJgXXPUt4LQXKBMsU93",
-      "name": "go-os-helper",
-      "version": "0.0.0"
     }
   ],
   "gxVersion": "0.8.0",


### PR DESCRIPTION
This will delete values that were in the process of being "put" when we crashed
but that's likely expected behavior anyways. Without this, ipfs on badger may
refuse to start after a crash.

part of https://github.com/ipfs/go-ipfs/issues/5275