### PR TITLE
Avoid discarding transaction too early in queries

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -23,6 +23,10 @@ type Datastore struct {
 // the badger Datastore.
 type txn struct {
 	txn *badger.Txn
+
+	// Whether this transaction has been implicitly created as a result of a direct Datastore
+	// method invocation.
+	implicit bool
 }
 
 // Options are the badger datastore options, reexported here for convenience.
@@ -79,11 +83,17 @@ func NewDatastore(path string, options *Options) (*Datastore, error) {
 // can be mutated without incurring changes to the underlying Datastore until
 // the transaction is Committed.
 func (d *Datastore) NewTransaction(readOnly bool) ds.Txn {
-	return &txn{d.DB.NewTransaction(!readOnly)}
+	return &txn{d.DB.NewTransaction(!readOnly), false}
+}
+
+// newImplicitTransaction creates a transaction marked as 'implicit'.
+// Implicit transactions are created by Datastore methods performing single operations.
+func (d *Datastore) newImplicitTransaction(readOnly bool) ds.Txn {
+	return &txn{d.DB.NewTransaction(!readOnly), true}
 }
 
 func (d *Datastore) Put(key ds.Key, value []byte) error {
-	txn := d.NewTransaction(false)
+	txn := d.newImplicitTransaction(false)
 	defer txn.Discard()
 
 	if err := txn.Put(key, value); err != nil {
@@ -94,7 +104,7 @@ func (d *Datastore) Put(key ds.Key, value []byte) error {
 }
 
 func (d *Datastore) PutWithTTL(key ds.Key, value []byte, ttl time.Duration) error {
-	txn := d.NewTransaction(false).(*txn)
+	txn := d.newImplicitTransaction(false).(*txn)
 	defer txn.Discard()
 
 	if err := txn.PutWithTTL(key, value, ttl); err != nil {
@@ -105,7 +115,7 @@ func (d *Datastore) PutWithTTL(key ds.Key, value []byte, ttl time.Duration) erro
 }
 
 func (d *Datastore) SetTTL(key ds.Key, ttl time.Duration) error {
-	txn := d.NewTransaction(false).(*txn)
+	txn := d.newImplicitTransaction(false).(*txn)
 	defer txn.Discard()
 
 	if err := txn.SetTTL(key, ttl); err != nil {
@@ -116,21 +126,21 @@ func (d *Datastore) SetTTL(key ds.Key, ttl time.Duration) error {
 }
 
 func (d *Datastore) Get(key ds.Key) (value []byte, err error) {
-	txn := d.NewTransaction(true)
+	txn := d.newImplicitTransaction(true)
 	defer txn.Discard()
 
 	return txn.Get(key)
 }
 
 func (d *Datastore) Has(key ds.Key) (bool, error) {
-	txn := d.NewTransaction(true)
+	txn := d.newImplicitTransaction(true)
 	defer txn.Discard()
 
 	return txn.Has(key)
 }
 
 func (d *Datastore) Delete(key ds.Key) error {
-	txn := d.NewTransaction(false)
+	txn := d.newImplicitTransaction(false)
 	defer txn.Discard()
 
 	err := txn.Delete(key)
@@ -142,9 +152,10 @@ func (d *Datastore) Delete(key ds.Key) error {
 }
 
 func (d *Datastore) Query(q dsq.Query) (dsq.Results, error) {
-	txn := d.NewTransaction(true)
-	defer txn.Discard()
-
+	txn := d.newImplicitTransaction(true)
+	// We cannot defer txn.Discard() here, as the txn must remain active while the iterator is open.
+	// https://github.com/dgraph-io/badger/commit/b1ad1e93e483bbfef123793ceedc9a7e34b09f79
+	// The closing logic in the query goprocess takes care of discarding the implicit transaction.
 	return txn.Query(q)
 }
 
@@ -243,6 +254,11 @@ func (t *txn) Query(q dsq.Query) (dsq.Results, error) {
 	qrb := dsq.NewResultBuilder(q)
 
 	qrb.Process.Go(func(worker goprocess.Process) {
+		if t.implicit {
+			// this iterator is part of an implicit transaction, so when we're done we must discard
+			// the transaction. It's safe to discard the txn it because it contains the iterator only.
+			defer t.Discard()
+		}
 		defer it.Close()
 
 		for sent := 0; it.ValidForPrefix(prefix); sent++ {


### PR DESCRIPTION
Tests against badger master are failing because of dgraph-io/badger@b1ad1e93e483bbfef123793ceedc9a7e34b09f79

As per that commit, badger now fails if a transaction holding an iterator is discarded while the iterator is still active.

This commit tracks _implicit transactions:_ those created solely to execute
one-off queries called on the `Datastore`. The goprocess for the iterator now calls `txn.Discard()` on implicit transactions on closure.