### PR TITLE
Ability to get entry expirations

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.6.1: QmUCfrikzKVGAfpE31RPwPd32fu1DYxSG7HTGCadba5Wza
+1.7.0: QmaiEBFgkgB1wjrPRxru5PyXPEkx58WuMjXNaR1Q9QNRjn

--- a/ds_test.go
+++ b/ds_test.go
@@ -672,3 +672,76 @@ func TestTTL(t *testing.T) {
 
 	d.Close()
 }
+
+func TestExpirations(t *testing.T) {
+	var err error
+
+	d, done := newDS(t)
+	defer done()
+
+	txn := d.NewTransaction(false)
+	ttltxn := txn.(ds.TTLDatastore)
+	defer txn.Discard()
+
+	key := ds.NewKey("/abc/def")
+	val := make([]byte, 32)
+	if n, err := rand.Read(val); n != 32 || err != nil {
+		t.Fatal("source of randomness failed")
+	}
+
+	ttl := time.Hour
+	now := time.Now()
+	tgt := now.Add(ttl)
+
+	if err = ttltxn.PutWithTTL(key, val, ttl); err != nil {
+		t.Fatalf("adding with ttl failed: %v", err)
+	}
+
+	if err = txn.Commit(); err != nil {
+		t.Fatalf("commiting transaction failed: %v", err)
+	}
+
+	// Second transaction to retrieve expirations.
+	txn = d.NewTransaction(true)
+	ttltxn = txn.(ds.TTLDatastore)
+	defer txn.Discard()
+
+	// GetExpiration returns expected value.
+	var dsExp time.Time
+	if dsExp, err = ttltxn.GetExpiration(key); err != nil {
+		t.Fatalf("getting expiration failed: %v", err)
+	} else if tgt.Sub(dsExp) >= 5*time.Second {
+		t.Fatal("expiration returned by datastore not within the expected range (tolerance: 5 seconds)")
+	} else if tgt.Sub(dsExp) < 0 {
+		t.Fatal("expiration returned by datastore was earlier than expected")
+	}
+
+	// Iterator returns expected value.
+	q := dsq.Query{
+		ReturnExpirations: true,
+		KeysOnly:          true,
+	}
+	var ress dsq.Results
+	if ress, err = txn.Query(q); err != nil {
+		t.Fatalf("querying datastore failed: %v", err)
+	}
+
+	defer ress.Close()
+	if res, ok := ress.NextSync(); !ok {
+		t.Fatal("expected 1 result in iterator")
+	} else if res.Expiration != dsExp {
+		t.Fatalf("expiration returned from iterator differs from GetExpiration, expected: %v, actual: %v", dsExp, res.Expiration)
+	}
+
+	if _, ok := ress.NextSync(); ok {
+		t.Fatal("expected no more results in iterator")
+	}
+
+	// Datastore->GetExpiration()
+	if exp, err := d.GetExpiration(key); err != nil {
+		t.Fatalf("querying datastore failed: %v", err)
+	} else if exp != dsExp {
+		t.Fatalf("expiration returned from DB differs from that returned by txn, expected: %v, actual: %v", dsExp, exp)
+	}
+
+}

--- a/ds_test.go
+++ b/ds_test.go
@@ -744,4 +744,7 @@ func TestExpirations(t *testing.T) {
 		t.Fatalf("expiration returned from DB differs from that returned by txn, expected: %v, actual: %v", dsExp, exp)
 	}
 
+	if _, err := d.GetExpiration(ds.NewKey("/foo/bar")); err != ds.ErrNotFound {
+		t.Fatalf("wrong error type: %v", err)
+	}
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "license": "",
   "name": "go-ds-badger",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.6.1"
+  "version": "1.7.0"
 }
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     },
     {
       "author": "jbenet",
-      "hash": "QmSpg1CvpXQQow5ernt1gNBXaXV6yxyNqi7XoeerWfzB5w",
+      "hash": "QmUyz7JTJzgegC6tiJrfby3mPhzcdswVtG4x58TQ6pq8jV",
       "name": "go-datastore",
-      "version": "3.1.0"
+      "version": "3.2.0"
     },
     {
       "author": "dgraph-io",


### PR DESCRIPTION
_(This PR builds upon #31, and shares the commit history with that one)._

This PR introduces the ability to get an entry's expiration as a: 
* datastore standalone operation. 
* as part of a transaction. 
* within an iterator.

Needs to go hand-in-hand with https://github.com/ipfs/go-datastore/pull/96.

Builds will fail until that PR is merged in.