### PR TITLE
tweak the default options

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	osh "github.com/Kubuxu/go-os-helper"
 	badger "github.com/dgraph-io/badger"
 	ds "github.com/ipfs/go-datastore"
 	dsq "github.com/ipfs/go-datastore/query"
@@ -67,12 +66,6 @@ func NewDatastore(path string, options *Options) (*Datastore, error) {
 	} else {
 		opt = options.Options
 		gcDiscardRatio = options.gcDiscardRatio
-	}
-
-	// TODO: remove this? We should let the user choose what they want to
-	// do.
-	if osh.IsWindows() && opt.SyncWrites {
-		opt.Truncate = true
 	}
 
 	opt.Dir = path

--- a/datastore.go
+++ b/datastore.go
@@ -38,10 +38,16 @@ type Options struct {
 	badger.Options
 }
 
-var DefaultOptions = Options{
-	gcDiscardRatio: 0.1,
+// DefaultOptions are the default options for the badger datastore.
+var DefaultOptions Options
 
-	Options: badger.DefaultOptions,
+func init() {
+	DefaultOptions = Options{
+		gcDiscardRatio: 0.1,
+		Options:        badger.DefaultOptions,
+	}
+	DefaultOptions.Options.CompactL0OnClose = false
+	DefaultOptions.Options.Truncate = true
 }
 
 var _ ds.Datastore = (*Datastore)(nil)
@@ -63,6 +69,8 @@ func NewDatastore(path string, options *Options) (*Datastore, error) {
 		gcDiscardRatio = options.gcDiscardRatio
 	}
 
+	// TODO: remove this? We should let the user choose what they want to
+	// do.
 	if osh.IsWindows() && opt.SyncWrites {
 		opt.Truncate = true
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/ipfs/go-ds-badger
 
 require (
 	github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7 // indirect
-	github.com/Kubuxu/go-os-helper v0.0.1
 	github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f
 	github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,7 @@
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7 h1:PqzgE6kAMi81xWQA2QIVxjWkFHptGgC547vchpUbtFo=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
-github.com/Kubuxu/go-os-helper v0.0.1 h1:EJiD2VUQyh5A9hWJLmc6iWg6yIcJ7jpBcwC8GMGXfDk=
-github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/badger v1.5.4 h1:gVTrpUTbbr/T24uvoCaqY2KSHfNLVGm0w+hbee2HMeg=
-github.com/dgraph-io/badger v1.5.4/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
-github.com/dgraph-io/badger v1.5.5-0.20181004181505-439fd464b155 h1:T4boC9W0W8nXwg7MAGjZRWkG+2yiJ56tQU4HjH/UM2g=
-github.com/dgraph-io/badger v1.5.5-0.20181004181505-439fd464b155/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f h1:6itBiEUtu+gOzXZWn46bM5/qm8LlV6/byR7Yflx/y6M=
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f h1:dDxpBYafY/GYpcl+LS4Bn3ziLPuEdGRkRjYAbSlWxSA=

--- a/package.json
+++ b/package.json
@@ -26,12 +26,6 @@
       "version": "2.11.4"
     },
     {
-      "author": "Kubuxu",
-      "hash": "QmXuBJ7DR6k3rmUEKtvVMhwjmXDuJgXXPUt4LQXKBMsU93",
-      "name": "go-os-helper",
-      "version": "0.0.0"
-    },
-    {
       "hash": "QmbkT7eMTyXfpeyB3ZMxxcxg7XH8t6uXp49jqzz4HB7BGF",
       "name": "go-log",
       "version": "1.5.9"


### PR DESCRIPTION
1. Disable CompactL0OnClose. That's only useful for users who open badger read-only and expect high-performance queries. We never do that.
2. Default Truncate to true. The user can still override this but, 99% of the time, this is what the user wants. We already set this in go-ipfs but setting it here gives libp2p users sane defaults.

fixes #42