### PR TITLE
fix: verify that the datastore is still open when querying

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -342,6 +342,9 @@ func (d *Datastore) Delete(key ds.Key) error {
 func (d *Datastore) Query(q dsq.Query) (dsq.Results, error) {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
+	if d.closed {
+		return nil, ErrClosed
+	}
 
 	txn := d.newImplicitTransaction(true)
 	// We cannot defer txn.Discard() here, as the txn must remain active while the iterator is open.


### PR DESCRIPTION
fixes part of https://github.com/ipfs/go-ipfs/issues/6986

(the other part is that we should be shutting down in the right order)