### PR TITLE
 Add Cancel function; add finalizer to cleanup abandoned batch

### DIFF
--- a/ds_test.go
+++ b/ds_test.go
@@ -322,7 +322,10 @@ func TestBatching(t *testing.T) {
 	}
 
 	// TODO: remove type assertion once datastore.Batch interface has Cancel
-	b.(*batch).Cancel()
+	err = b.(*batch).Cancel()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = d.Get(ds.NewKey(key))
 	if err == nil {

--- a/ds_test.go
+++ b/ds_test.go
@@ -307,6 +307,27 @@ func TestBatching(t *testing.T) {
 		"/g",
 	}, rs)
 
+	//Test cancel
+
+	b, err = d.Batch()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const key = "/xyz"
+
+	err = b.Put(ds.NewKey(key), []byte("/x/y/z"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TODO: remove type assertion once datastore.Batch interface has Cancel
+	b.(*batch).Cancel()
+
+	_, err = d.Get(ds.NewKey(key))
+	if err == nil {
+		t.Fatal("expected error trying to get uncommited data")
+	}
 }
 
 func TestBatchingRequired(t *testing.T) {


### PR DESCRIPTION
This allows `Cancel` to be added to `datastore.Batch` interface at a later time